### PR TITLE
fix: Request too large when updating list of envs

### DIFF
--- a/apps/backend/src/api/public-api.ts
+++ b/apps/backend/src/api/public-api.ts
@@ -28,8 +28,8 @@ import { StatsJump } from '@prisma/client';
 
 export const publicApi = Router();
 
-publicApi.use(express.json());
-publicApi.use(express.raw({ type: '*/*', limit: '10mb' }));
+publicApi.use(express.json({ limit: '20mb' }));
+publicApi.use(express.raw({ type: '*/*', limit: '20mb' }));
 
 publicApi.get(
   '/api/config',


### PR DESCRIPTION
When updating list of envs `{{env-hopper-url}}/api/envs` there was an error that entity is too large