### PR TITLE
feat(history): increase visible history from 10 to 50 items

### DIFF
--- a/apps/frontend/src/app/ui/History.tsx
+++ b/apps/frontend/src/app/ui/History.tsx
@@ -38,7 +38,7 @@ export function History({ className }: RecentJumpsProps) {
               </tr>
             </thead>
             <tbody>
-              {recentJumps.slice(0, 10).map((jump) => (
+              {recentJumps.slice(0, 50).map((jump) => (
                 <tr
                   key={`${jump.app}-${jump.env}-${jump.substitution || ''}`}
                   className="hover"


### PR DESCRIPTION
## What

Increases the number of recent jumps shown in the History table from **10** to **50**.
